### PR TITLE
Float32 support

### DIFF
--- a/src/transform.jl
+++ b/src/transform.jl
@@ -1,40 +1,42 @@
-struct LogTransformModel <: ProjectionModel
+struct LogTransformModel{T} <: ProjectionModel
 	scale_factor::Float64
 	var_match::DataFrame
 	var::Symbol
 	obs::Symbol
 end
-function LogTransformModel(counts::DataMatrix;
+function LogTransformModel(::Type{T}, counts::DataMatrix;
                            var_filter = hasproperty(counts.var, :feature_type) ? :feature_type => isequal("Gene Expression") : nothing,
-                           scale_factor=10_000, var=:copy, obs=:copy)
+                           scale_factor=10_000, var=:copy, obs=:copy) where T
 	var_match = select(counts.var, counts.var_id_cols)
 	if var_filter !== nothing
 		sub = filter(var_filter, counts.var; view=true)
 		ind = first(parentindices(sub))
 		var_match = var_match[ind,:]
 	end
-	LogTransformModel(scale_factor, var_match, var, obs)
+	LogTransformModel{T}(scale_factor, var_match, var, obs)
 end
+LogTransformModel(counts::DataMatrix; kwargs...) = LogTransformModel(Float64, counts; kwargs...)
 
-projection_isequal(m1::LogTransformModel, m2::LogTransformModel) =
-	m1.scale_factor == m2.scale_factor && m1.var_match == m2.var_match
+projection_isequal(m1::LogTransformModel{T1}, m2::LogTransformModel{T2}) where {T1,T2} =
+	T1 === T2 && m1.scale_factor == m2.scale_factor && m1.var_match == m2.var_match
 
-update_model(m::LogTransformModel; scale_factor=m.scale_factor, var=m.var, obs=m.obs, kwargs...) =
-	(LogTransformModel(scale_factor, m.var_match, var, obs), kwargs)
+update_model(m::LogTransformModel{T}; scale_factor=m.scale_factor, var=m.var, obs=m.obs, kwargs...) where T =
+	(LogTransformModel{T}(scale_factor, m.var_match, var, obs), kwargs)
 
 
-function logtransform_impl(X, model::LogTransformModel)
+function logtransform_impl(X, model::LogTransformModel{T}) where T
 	P,N = size(X)
 	s = max.(1, sum(X; dims=1))
 	nf = model.scale_factor ./ s
 
 	# log( 1 + c*f/s)
 	nzval = nonzeros(X)
-	nzval_out = zeros(nnz(X))
+	nzval_out = zeros(T, nnz(X))
 
 	for j in 1:N
 		irange = nzrange(X,j)
-		nzval_out[irange] .= log2.(1 .+ (@view nzval[irange]) .* nf[j])
+		# nzval_out[irange] .= log2.(1 .+ (@view nzval[irange]) .* nf[j])
+		nzval_out[irange] .= convert.(T, log2.(1 .+ (@view nzval[irange]) .* nf[j]))
 	end
 
 	A = SparseMatrixCSC(P, N, copy(X.colptr), copy(X.rowval), nzval_out)
@@ -92,11 +94,12 @@ julia> transformed = logtransform(counts)
 
 See also: [`sctransform`](@ref)
 """
-logtransform(counts::DataMatrix; kwargs...) = project(counts, LogTransformModel(counts; kwargs...))
+logtransform(::Type{T}, counts::DataMatrix; kwargs...) where T =
+	project(counts, LogTransformModel(T, counts; kwargs...))
+logtransform(counts::DataMatrix; kwargs...) = logtransform(Float64, counts; kwargs...)
 
 
-
-struct TFIDFTransformModel <: ProjectionModel
+struct TFIDFTransformModel{T} <: ProjectionModel
 	scale_factor::Float64
 	idf::Vector{Float64}
 	var_match::DataFrame
@@ -104,30 +107,33 @@ struct TFIDFTransformModel <: ProjectionModel
 	var::Symbol
 	obs::Symbol
 end
-function TFIDFTransformModel(counts::DataMatrix;
+function TFIDFTransformModel(::Type{T}, counts::DataMatrix;
                              var_filter = hasproperty(counts.var, :feature_type) ? :feature_type => isequal("Gene Expression") : nothing,
                              scale_factor=10_000,
                              idf=vec(size(counts,2) ./ max.(1,sum(counts.matrix; dims=2))),
                              annotate=true,
-                             var=:copy, obs=:copy)
+                             var=:copy, obs=:copy) where T
 	var_match = select(counts.var, counts.var_id_cols)
 	if var_filter !== nothing
 		sub = filter(var_filter, counts.var; view=true)
 		ind = first(parentindices(sub))
 		var_match = var_match[ind,:]
 	end
-	TFIDFTransformModel(scale_factor, idf, var_match, annotate, var, obs)
+	TFIDFTransformModel{T}(scale_factor, idf, var_match, annotate, var, obs)
 end
+TFIDFTransformModel(counts::DataMatrix; kwargs...) =
+	TFIDFTransformModel(Float64, counts; kwargs...)
 
-projection_isequal(m1::TFIDFTransformModel, m2::TFIDFTransformModel) =
-	m1.scale_factor == m2.scale_factor && m1.idf == m2.idf && m1.var_match == m2.var_match
+projection_isequal(m1::TFIDFTransformModel{T1}, m2::TFIDFTransformModel{T2}) where {T1,T2} =
+	T1 === T2 && m1.scale_factor == m2.scale_factor && m1.idf == m2.idf && m1.var_match == m2.var_match
 
-update_model(m::TFIDFTransformModel; scale_factor=m.scale_factor, idf=m.idf,
-                                     annotate=m.annotate, var=m.var, obs=m.obs, kwargs...) =
-	(TFIDFTransformModel(scale_factor, idf, m.var_match, annotate, var, obs), kwargs)
+update_model(m::TFIDFTransformModel{T}; scale_factor=m.scale_factor, idf=m.idf,
+                                        annotate=m.annotate, var=m.var, obs=m.obs,
+                                        kwargs...) where T =
+	(TFIDFTransformModel{T}(scale_factor, idf, m.var_match, annotate, var, obs), kwargs)
 
 
-function tf_idf_transform_impl(X, scale_factor, idf)
+function tf_idf_transform_impl(::Type{T}, X, scale_factor, idf) where T
 	P,N = size(X)
 	s = max.(1, sum(X; dims=1))
 	nf = scale_factor ./ s
@@ -135,12 +141,13 @@ function tf_idf_transform_impl(X, scale_factor, idf)
 	# log( 1 + c*f/s * idf )
 	R = rowvals(X)
 	nzval = nonzeros(X)
-	nzval_out = zeros(nnz(X))
+	nzval_out = zeros(T, nnz(X))
 
 	for j in 1:N
 		for k in nzrange(X,j)
 			i = R[k]
-			nzval_out[k] = log(1.0 + nzval[k]*nf[j]*idf[i])
+			# nzval_out[k] = log(1.0 + nzval[k]*nf[j]*idf[i])
+			nzval_out[k] = convert(T, log(1.0 + nzval[k]*nf[j]*idf[i]))
 		end
 	end
 
@@ -148,7 +155,7 @@ function tf_idf_transform_impl(X, scale_factor, idf)
 	MatrixRef(:A=>A)
 end
 
-function project_impl(counts::DataMatrix, model::TFIDFTransformModel; verbose=true)
+function project_impl(counts::DataMatrix, model::TFIDFTransformModel{T}; verbose=true) where T
 	# TODO: share this code with LogTransformModel - the only difference is idf
 	matrix = counts.matrix
 	var = model.var
@@ -176,7 +183,7 @@ function project_impl(counts::DataMatrix, model::TFIDFTransformModel; verbose=tr
 		end
 	end
 
-	matrix = tf_idf_transform_impl(matrix, model.scale_factor, idf)
+	matrix = tf_idf_transform_impl(T, matrix, model.scale_factor, idf)
 
 	if model.annotate
 		if var isa Symbol
@@ -204,14 +211,17 @@ the formula `log( 1 + scale_factor * tf * idf )` where `tf` is the term frequenc
 * `var` - Can be `:copy` (make a copy of source `var`) or `:keep` (share the source `var` object).
 * `obs` - Can be `:copy` (make a copy of source `obs`) or `:keep` (share the source `obs` object).
 """
-tf_idf_transform(counts::DataMatrix; kwargs...) = project(counts, TFIDFTransformModel(counts; kwargs...))
+tf_idf_transform(::Type{T}, counts::DataMatrix; kwargs...) where T =
+	project(counts, TFIDFTransformModel(T, counts; kwargs...))
+tf_idf_transform(counts::DataMatrix; kwargs...) =
+	tf_idf_transform(Float64, counts; kwargs...)
 
 
 
 
 scparams(counts::DataMatrix; kwargs...) = scparams(counts.matrix, counts.var; kwargs...)
 
-struct SCTransformModel <: ProjectionModel
+struct SCTransformModel{T} <: ProjectionModel
 	params::DataFrame
 	var_id_cols::Vector{String}
 	clip::Float64
@@ -254,12 +264,12 @@ julia> SCTransformModel(counts; var_filter = :feature_type => isequal("Antibody 
 
 See also: [`sctransform`](@ref), [`SCTransform.scparams`](https://github.com/rasmushenningsson/SCTransform.jl), [`DataFrames.filter`](https://dataframes.juliadata.org/stable/lib/functions/#Base.filter)
 """
-function SCTransformModel(counts::DataMatrix;
+function SCTransformModel(::Type{T}, counts::DataMatrix;
                           var_filter = hasproperty(counts.var, :feature_type) ? :feature_type => isequal("Gene Expression") : nothing,
                           rtol=1e-3, atol=0.0, annotate=true,
                           post_var_filter=:, post_obs_filter=:,
                           obs=:copy,
-                          kwargs...)
+                          kwargs...) where T
 	nvar = size(counts,1)
 
 	if var_filter === nothing
@@ -274,10 +284,11 @@ function SCTransformModel(counts::DataMatrix;
 	params = scparams(counts; feature_mask, kwargs...)
 	clip = sqrt(size(counts,2)/30)
 	post_filter = FilterModel(params, counts.var_id_cols, post_var_filter, post_obs_filter; var=:copy, obs)
-	SCTransformModel(params, counts.var_id_cols, clip, rtol, atol, annotate, post_filter)
+	SCTransformModel{T}(params, counts.var_id_cols, clip, rtol, atol, annotate, post_filter)
 end
 
-function projection_isequal(m1::SCTransformModel, m2::SCTransformModel)
+function projection_isequal(m1::SCTransformModel{T1}, m2::SCTransformModel{T2}) where {T1,T2}
+	T1 === T2 &&
 	m1.params == m2.params &&
 	m1.var_id_cols == m2.var_id_cols &&
 	m1.clip == m2.clip &&
@@ -287,26 +298,26 @@ function projection_isequal(m1::SCTransformModel, m2::SCTransformModel)
 end
 
 
-function update_model(m::SCTransformModel;
+function update_model(m::SCTransformModel{T};
                       clip=m.clip, rtol=m.rtol, atol=m.atol,
                       annotate=m.annotate,
                       post_var_filter=m.post_filter.var_filter,
                       post_obs_filter=nothing,
                       obs=m.post_filter.obs,
                       kwargs...
-                     )
+                     ) where T
 	post_var_filter = _filter_indices(m.params, post_var_filter)
 
 	allow_obs_indexing = post_obs_filter !== nothing
 	post_obs_filter === nothing && (post_obs_filter = m.post_filter.obs_filter)
 
 	post_filter = FilterModel(post_var_filter, post_obs_filter, m.post_filter.var_match, m.post_filter.var, obs)
-	model = SCTransformModel(m.params, m.var_id_cols, clip, rtol, atol, annotate, post_filter)
+	model = SCTransformModel{T}(m.params, m.var_id_cols, clip, rtol, atol, annotate, post_filter)
 	(model, (;allow_obs_indexing, kwargs...))
 end
 
 
-function project_impl(counts::DataMatrix, model::SCTransformModel; allow_obs_indexing=false, verbose=true)
+function project_impl(counts::DataMatrix, model::SCTransformModel{T}; allow_obs_indexing=false, verbose=true) where T
 	# use post_filter to figure out variable and observations subsetting
 	_validate(model.params, model.post_filter, allow_obs_indexing, SCTransformModel, "post_obs_filter")
 
@@ -333,7 +344,7 @@ function project_impl(counts::DataMatrix, model::SCTransformModel; allow_obs_ind
 		end
 	end
 
-	X,var = sctransformsparse(counts.matrix, counts.var, params;
+	X,var = sctransformsparse(T, counts.matrix, counts.var, params;
 	                          feature_id_columns=model.var_id_cols,
 	                          cell_ind=J,
 	                          model.clip, model.rtol, model.atol)
@@ -371,17 +382,23 @@ julia> sctransform(counts; var_filter = :feature_type => isequal("Antibody Captu
 
 See also: [`SCTransformModel`](@ref), [`SCTransform.scparams`](https://github.com/rasmushenningsson/SCTransform.jl)
 """
-sctransform(counts::DataMatrix; verbose=true, kwargs...) =
-	project_impl(counts, SCTransformModel(counts; verbose, kwargs...); verbose, allow_obs_indexing=true)
-
+sctransform(::Type{T}, counts::DataMatrix; verbose=true, kwargs...) where T =
+	project_impl(counts, SCTransformModel(T, counts; verbose, kwargs...); verbose, allow_obs_indexing=true)
+sctransform(counts::DataMatrix; kwargs...) = sctransform(Float64, counts; kwargs...)
 
 # - show -
-function Base.show(io::IO, ::MIME"text/plain", model::LogTransformModel)
-	print(io, "LogTransformModel(scale_factor=", round(model.scale_factor;digits=2), ')')
+function Base.show(io::IO, ::MIME"text/plain", model::LogTransformModel{T}) where T
+	print(io, "LogTransformModel")
+	T !== Float64 && print(io, '{', T, '}')
+	print(io, "(scale_factor=", round(model.scale_factor;digits=2), ')')
 end
-function Base.show(io::IO, ::MIME"text/plain", model::TFIDFTransformModel)
-	print(io, "TFIDFTransformModel(scale_factor=", round(model.scale_factor;digits=2), ')')
+function Base.show(io::IO, ::MIME"text/plain", model::TFIDFTransformModel{T}) where T
+	print(io, "TFIDFTransformModel")
+	T !== Float64 && print(io, '{', T, '}')
+	print(io, "(scale_factor=", round(model.scale_factor;digits=2), ')')
 end
-function Base.show(io::IO, ::MIME"text/plain", model::SCTransformModel)
-	print(io, "SCTransformModel(nvar=", size(model.params,1), ", clip=", round(model.clip;digits=2), ')')
+function Base.show(io::IO, ::MIME"text/plain", model::SCTransformModel{T}) where T
+	print(io, "SCTransformModel")
+	T !== Float64 && print(io, '{', T, '}')
+	print(io, "(nvar=", size(model.params,1), ", clip=", round(model.clip;digits=2), ')')
 end

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -72,7 +72,7 @@ function project_impl(counts::DataMatrix, model::LogTransformModel; verbose=true
 end
 
 """
-	logtransform(counts::DataMatrix;
+	logtransform([T=Float64], counts::DataMatrix;
 	             var_filter = hasproperty(counts.var, :feature_type) ? :feature_type => isequal("Gene Expression") : nothing,
 	             scale_factor=10_000,
 	             var=:copy,
@@ -83,6 +83,9 @@ Log₂-transform `counts` using the formula:
   log₂(1 + cᵢⱼ*scale_factor/(∑ᵢcᵢⱼ))
 ```
 
+Optionally, `T` can be specified to control the `eltype` of the sparse transformed matrix.
+`T=Float32` can be used to lower the memory usage, with little impact on the results, since downstream analysis is still done with Float64.
+
 * `var_filter` - Control which variables (features) to use for parameter estimation. Defaults to `:feature_type => isequal("Gene Expression")`, if a `feature_type` column is present in `counts.var`. Can be set to `nothing` to disable filtering. See [`DataFrames.filter`](https://dataframes.juliadata.org/stable/lib/functions/#Base.filter) for how to specify filters.
 * `var` - Can be `:copy` (make a copy of source `var`) or `:keep` (share the source `var` object).
 * `obs` - Can be `:copy` (make a copy of source `obs`) or `:keep` (share the source `obs` object).
@@ -90,6 +93,11 @@ Log₂-transform `counts` using the formula:
 # Examples
 ```julia
 julia> transformed = logtransform(counts)
+```
+
+Use eltype Float32 to lower memory usage:
+```julia
+julia> transformed = logtransform(Float32, counts)
 ```
 
 See also: [`sctransform`](@ref)
@@ -195,7 +203,7 @@ function project_impl(counts::DataMatrix, model::TFIDFTransformModel{T}; verbose
 end
 
 """
-	tf_idf_transform(counts::DataMatrix;
+	tf_idf_transform([T=Float64], counts::DataMatrix;
 	                 var_filter = hasproperty(counts.var, :feature_type) ? :feature_type => isequal("Gene Expression") : nothing,
 	                 scale_factor = 10_000,
 	                 idf = vec(size(counts,2) ./ max.(1,sum(counts.matrix; dims=2))),
@@ -205,6 +213,9 @@ end
 
 Compute the TF-IDF (term frequency-inverse document frequency) transform of `counts`, using
 the formula `log( 1 + scale_factor * tf * idf )` where `tf` is the term frequency `counts.matrix ./ max.(1, sum(counts.matrix; dims=1))`.
+
+Optionally, `T` can be specified to control the `eltype` of the sparse transformed matrix.
+`T=Float32` can be used to lower the memory usage, with little impact on the results, since downstream analysis is still done with Float64.
 
 * `var_filter` - Control which variables (features) to use for parameter estimation. Defaults to `:feature_type => isequal("Gene Expression")`, if a `feature_type` column is present in `counts.var`. Can be set to `nothing` to disable filtering. See [`DataFrames.filter`](https://dataframes.juliadata.org/stable/lib/functions/#Base.filter) for how to specify filters.
 * `annotate` - If true, `idf` will be added as a `var` annotation.
@@ -232,7 +243,7 @@ struct SCTransformModel{T} <: ProjectionModel
 end
 
 """
-	SCTransformModel(counts::DataMatrix;
+	SCTransformModel([T=Float64], counts::DataMatrix;
 	                 var_filter = hasproperty(counts.var, :feature_type) ? :feature_type => isequal("Gene Expression") : nothing,
 	                 rtol=1e-3, atol=0.0, annotate=true,
 	                 post_var_filter=:, post_obs_filter=:,
@@ -241,6 +252,9 @@ end
 
 Computes the `SCTransform` parameter estimates for `counts` and creates a SCTransformModel that can be applied to the same or another data set.
 Defaults to only using "Gene Expression" features.
+
+Optionally, `T` can be specified to control the `eltype` of the sparse transformed matrix.
+`T=Float32` can be used to lower the memory usage, with little impact on the results, since downstream analysis is still done with Float64.
 
 * `var_filter` - Control which variables (features) to use for parameter estimation. Defaults to `:feature_type => isequal("Gene Expression")`, if a `feature_type` column is present in `counts.var`. Can be set to `nothing` to disable filtering. See [`DataFrames.filter`](https://dataframes.juliadata.org/stable/lib/functions/#Base.filter) for how to specify filters.
 * `rtol` - Relative tolerance when constructing low rank approximation.
@@ -361,11 +375,14 @@ end
 
 
 """
-	sctransform(counts::DataMatrix; verbose=true, kwargs...)
+	sctransform([T=Float64], counts::DataMatrix; verbose=true, kwargs...)
 
 Compute the SCTransform of the DataMatrix `counts`.
 The result is stored as a Matrix Expression with the sum of a sparse and a low-rank term.
 I.e. no large dense matrix is created.
+
+Optionally, `T` can be specified to control the `eltype` of the sparse transformed matrix.
+`T=Float32` can be used to lower the memory usage, with little impact on the results, since downstream analysis is still done with Float64.
 
 See `SCTransformModel` for description of `kwargs...`.
 
@@ -378,6 +395,11 @@ julia> sctransform(counts)
 Compute SCTransform (Antibody Capture features):
 ```
 julia> sctransform(counts; var_filter = :feature_type => isequal("Antibody Capture"))
+```
+
+Compute SCTransform (Gene Expression features), using eltype Float32 to lower memory usage:
+```
+julia> sctransform(Float32, counts)
 ```
 
 See also: [`SCTransformModel`](@ref), [`SCTransform.scparams`](https://github.com/rasmushenningsson/SCTransform.jl)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -66,7 +66,6 @@
 			trans = sctransform(Float32, counts; use_cache=false)
 			trans_proj = project(counts_proj, trans)
 			t2 = sctransform(T, counts; use_cache=false, var_filter=nothing)
-			sct = T.(sct)
 		end
 
 		@test params.logGeneMean ≈ trans.var.logGeneMean
@@ -76,11 +75,11 @@
 		@test params.theta ≈ trans.var.theta
 
 		@test size(trans.matrix) == size(sct)
-		@test materialize(trans) ≈ sct rtol=1e-3
 		@test eltype(trans.matrix.terms[1].matrix) == T
+		@test materialize(trans) ≈ sct rtol=1e-3
 
-		@test materialize(trans_proj) ≈ sct[:,proj_obs_indices] rtol=1e-3
 		@test eltype(trans_proj.matrix.terms[1].matrix) == T
+		@test materialize(trans_proj) ≈ sct[:,proj_obs_indices] rtol=1e-3
 
 		@test params.logGeneMean ≈ trans_proj.var.logGeneMean
 		@test params.outlier == trans_proj.var.outlier

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -8,59 +8,88 @@
 	proj_obs_indices = identity.(indexin(counts_proj.obs.barcode, counts.obs.barcode))
 
 
-	@testset "logtransform scale_factor=$scale_factor" for scale_factor in (10_000, 1_000)
+	@testset "logtransform scale_factor=$scale_factor T=$T" for scale_factor in (10_000, 1_000), T in (Float64,Float32)
 		X = simple_logtransform(expected_mat, scale_factor)
 		kwargs = scale_factor == 10_000 ? (;) : (;scale_factor)
-		l = logtransform(counts; kwargs...)
+		if T==Float64
+			l = logtransform(counts; kwargs...)
+		else
+			l = logtransform(T, counts; kwargs...)
+			X = T.(X)
+		end
+
 		@test l.matrix.matrix ≈ X
 		@test nnz(l.matrix.matrix) == expected_nnz
+		@test eltype(l.matrix.matrix) == T
 
 		lproj = project(counts_proj, l)
 		@test lproj.matrix.matrix ≈ X[:,proj_obs_indices]
+		@test eltype(lproj.matrix.matrix) == T
 
 		test_show(l; matrix="SparseMatrixCSC", var=names(counts.var), obs=names(counts.obs), models="LogTransformModel")
 		test_show(lproj; matrix="SparseMatrixCSC", var=names(counts_proj.var), obs=names(counts_proj.obs), models="LogTransformModel")
 	end
 
-	@testset "tf-idf scale_factor=$scale_factor" for scale_factor in (10_000, 1_000)
+	@testset "tf-idf scale_factor=$scale_factor T=$T" for scale_factor in (10_000, 1_000), T in (Float64,Float32)
 		idf = simple_idf(expected_mat)
 		X = simple_tf_idf_transform(expected_mat, idf, scale_factor)
 		kwargs = scale_factor == 10_000 ? (;) : (;scale_factor)
-		tf = tf_idf_transform(counts; kwargs...)
+
+		if T==Float64
+			tf = tf_idf_transform(counts; kwargs...)
+		else
+			tf = tf_idf_transform(T, counts; kwargs...)
+			X = T.(X)
+		end
+
 		@test tf.matrix.matrix ≈ X
 		@test nnz(tf.matrix.matrix) == expected_nnz
+		@test eltype(tf.matrix.matrix) == T
 
 		tf_proj = project(counts_proj, tf)
 		@test tf_proj.matrix.matrix ≈ X[:,proj_obs_indices]
+		@test eltype(tf_proj.matrix.matrix) == T
 
 		test_show(tf; matrix="SparseMatrixCSC", var=vcat(names(counts.var),"idf"), obs=names(counts.obs), models="TFIDFTransformModel")
 		test_show(tf_proj; matrix="SparseMatrixCSC", var=vcat(names(counts_proj.var),"idf"), obs=names(counts_proj.obs), models="TFIDFTransformModel")
 	end
 
 	transformed_proj = project(counts_proj, transformed)
-	@testset "sctransform" begin
-		@test params.logGeneMean ≈ transformed.var.logGeneMean
-		@test params.outlier == transformed.var.outlier
-		@test params.beta0 ≈ transformed.var.beta0
-		@test params.beta1 ≈ transformed.var.beta1
-		@test params.theta ≈ transformed.var.theta
-
+	@testset "sctransform T=$T" for T in (Float64,Float32)
 		sct = sctransform(expected_sparse, counts.var, params)
 
-		@test size(transformed.matrix) == size(sct)
-		@test materialize(transformed) ≈ sct rtol=1e-3
+		if T==Float64
+			trans = transformed
+			trans_proj = transformed_proj
+			t2 = sctransform(counts; use_cache=false, var_filter=nothing)
+		else
+			trans = sctransform(Float32, counts; use_cache=false)
+			trans_proj = project(counts_proj, trans)
+			t2 = sctransform(T, counts; use_cache=false, var_filter=nothing)
+			sct = T.(sct)
+		end
 
-		@test materialize(transformed_proj) ≈ sct[:,proj_obs_indices] rtol=1e-3
+		@test params.logGeneMean ≈ trans.var.logGeneMean
+		@test params.outlier == trans.var.outlier
+		@test params.beta0 ≈ trans.var.beta0
+		@test params.beta1 ≈ trans.var.beta1
+		@test params.theta ≈ trans.var.theta
 
-		@test params.logGeneMean ≈ transformed_proj.var.logGeneMean
-		@test params.outlier == transformed_proj.var.outlier
-		@test params.beta0 ≈ transformed_proj.var.beta0
-		@test params.beta1 ≈ transformed_proj.var.beta1
-		@test params.theta ≈ transformed_proj.var.theta
+		@test size(trans.matrix) == size(sct)
+		@test materialize(trans) ≈ sct rtol=1e-3
+		@test eltype(trans.matrix.terms[1].matrix) == T
 
-		test_show(transformed; matrix=r"^A\+B₁B₂B₃$", models="SCTransformModel")
+		@test materialize(trans_proj) ≈ sct[:,proj_obs_indices] rtol=1e-3
+		@test eltype(trans_proj.matrix.terms[1].matrix) == T
 
-		t2 = sctransform(counts; use_cache=false, var_filter=nothing)
+		@test params.logGeneMean ≈ trans_proj.var.logGeneMean
+		@test params.outlier == trans_proj.var.outlier
+		@test params.beta0 ≈ trans_proj.var.beta0
+		@test params.beta1 ≈ trans_proj.var.beta1
+		@test params.theta ≈ trans_proj.var.theta
+
+		test_show(trans; matrix=r"^A\+B₁B₂B₃$", models="SCTransformModel")
+
 		@test materialize(t2) ≈ sct rtol=1e-3
 	end
 


### PR DESCRIPTION
Support for specifying eltype of the transformed sparse matrix. Typically used to reduce memory usage by using Float32.
All downstream computations are still done in Float64, i.e. the numerical effect on the results should be minimal.